### PR TITLE
fix: Incorrect base class checker tests obsolete import

### DIFF
--- a/pylint_nautobot/incorrect_base_class.py
+++ b/pylint_nautobot/incorrect_base_class.py
@@ -6,11 +6,6 @@ from pylint.checkers import BaseChecker
 from pylint.interfaces import IAstroidChecker
 
 
-def to_path(obj):
-    """Given an object, return its fully qualified import path."""
-    return f"{inspect.getmodule(obj).__name__}.{obj.__name__}"
-
-
 def is_abstract(node):
     """Given a node, returns whether it is an abstract base model."""
     for child_node in node.get_children():
@@ -45,7 +40,7 @@ class NautobotIncorrectBaseClassChecker(BaseChecker):
     external_to_nautobot_class_mapping = [
         ("django_filters.filters.FilterSet", "django_filters.filters.BaseFilterSet"),
         ("django.db.models.base.Model", "nautobot.core.models.BaseModel"),
-        ("django.forms.forms.Form", "nautobot.utilities.forms.forms.BootstrapMixin"),
+        ("django.forms.forms.Form", "nautobot.core.forms.forms.BootstrapMixin"),
     ]
 
     name = "nautobot-incorrect-base-class"

--- a/pylint_nautobot/incorrect_base_class.py
+++ b/pylint_nautobot/incorrect_base_class.py
@@ -3,6 +3,8 @@ from astroid import ClassDef, Assign, Const
 from pylint.checkers import BaseChecker
 from pylint.interfaces import IAstroidChecker
 
+from pylint_nautobot.utils import is_nautobot_v2_installed
+
 
 def is_abstract(node):
     """Given a node, returns whether it is an abstract base model."""
@@ -38,7 +40,12 @@ class NautobotIncorrectBaseClassChecker(BaseChecker):
     external_to_nautobot_class_mapping = [
         ("django_filters.filters.FilterSet", "django_filters.filters.BaseFilterSet"),
         ("django.db.models.base.Model", "nautobot.core.models.BaseModel"),
-        ("django.forms.forms.Form", "nautobot.core.forms.forms.BootstrapMixin"),
+        (
+            "django.forms.forms.Form",
+            "nautobot.core.forms.forms.BootstrapMixin"
+            if is_nautobot_v2_installed()
+            else "nautobot.utilities.forms.forms.BootstrapMixin",
+        ),
     ]
 
     name = "nautobot-incorrect-base-class"

--- a/pylint_nautobot/incorrect_base_class.py
+++ b/pylint_nautobot/incorrect_base_class.py
@@ -1,6 +1,4 @@
 """Check for imports whose paths have changed in 2.0."""
-import inspect
-
 from astroid import ClassDef, Assign, Const
 from pylint.checkers import BaseChecker
 from pylint.interfaces import IAstroidChecker

--- a/pylint_nautobot/utils.py
+++ b/pylint_nautobot/utils.py
@@ -3,6 +3,20 @@ from importlib_resources import files
 from yaml import safe_load
 
 
+def is_nautobot_v2_installed() -> bool:
+    """Return True if Nautobot v2.x is installed."""
+    try:
+        # pylint: disable-next=import-outside-toplevel
+        from importlib.metadata import version
+
+        # pylint: disable-next=import-outside-toplevel
+        from packaging.version import Version
+
+        return Version(version("nautobot")).major == 2
+    except ImportError:
+        return False
+
+
 def load_v2_code_location_changes():
     """Black magic data transform, needs schema badly."""
     with open(files("pylint_nautobot") / "data" / "v2" / "v2-code-location-changes.yaml", encoding="utf-8") as rules:


### PR DESCRIPTION
# Closes: NaN

Incorrect base class checker tests obsolete `nautobot.utilities...` import to be used.

## What's Changed

- Fixed incorrect base class checker for `Form` classes for Nautobot v2
- Removed unused `to_path` function.
