### PR TITLE
Improve rule help messages and fix scoping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,10 @@
 # Swap files
 *.swp
 
+# Vagrant
+.vagrant
+Vagrantfile
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN apt-get update && \
 RUN pip install --upgrade pip
 
 RUN curl -sSL https://install.python-poetry.org -o /tmp/install-poetry.py && \
-    python /tmp/install-poetry.py && \
+    python /tmp/install-poetry.py --version 1.5.1 && \
     rm -f /tmp/install-poetry.py
 
 # Add poetry install location to the $PATH

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -61,6 +61,25 @@ Test whether the new rules are enabled by running the following (this is just a 
 
 You can now run `pylint` within your project as you normally would and the additional rules will be automatically checked.
 
+### Viewing a rule's extended description
+
+Sometimes the short name of the rule displayed in the output of `pylint` will not be enough to understand the problem:
+
+```
+nautobot_golden_config/models.py:216:4: E4261: Uses bad parameter combination for TextField/CharField. (nb-string-field-blank-null)
+```
+
+All rules also have additional information that can be viewed with the `--help-msg=rule-id` command line parameter:
+
+```
+> poetry run pylint --help-msg=E4261
+:nb-string-field-blank-null (E4261): *Uses bad parameter combination for TextField/CharField.*
+  Don't use blank=true and null=true on TextField or CharField. It avoids
+  confusion between a value of None and a value of "" potentially having
+  different meanings. This message belongs to the nautobot-string-field-blank-
+  null checker.
+```
+
 ## Authors and Maintainers
 
 - [Cristian Sirbu](https://github.com/cmsirbu)

--- a/pylint_nautobot/code_location_changes.py
+++ b/pylint_nautobot/code_location_changes.py
@@ -16,12 +16,12 @@ class NautobotCodeLocationChangesChecker(BaseChecker):
         "E4251": (
             "Import location has changed (%s -> %s).",
             "nb-code-location-changed",
-            "https://docs.nautobot.com/projects/core/en/next/installation/upgrading-from-nautobot-v1/#python-code-location-changes",
+            "Reference: https://docs.nautobot.com/projects/core/en/next/development/apps/migration/code-updates/",
         ),
         "E4252": (
             "Import location has changed for %s (%s -> %s).",
             "nb-code-location-changed-object",
-            "https://docs.nautobot.com/projects/core/en/next/installation/upgrading-from-nautobot-v1/#python-code-location-changes",
+            "Reference: https://docs.nautobot.com/projects/core/en/next/development/apps/migration/code-updates/",
         ),
     }
 

--- a/pylint_nautobot/deprecated_status_model.py
+++ b/pylint_nautobot/deprecated_status_model.py
@@ -15,8 +15,7 @@ class NautobotDeprecatedStatusModelChecker(BaseChecker):
         "E4292": (
             "Inherits from the deprecated StatusModel instead of declaring status on the model explicitly with StatusField",
             "nb-status-field-instead-of-status-model",
-            # TBD: Link is not accessible
-            "https://docs.nautobot.com/projects/core/en/next/models/extras/status/#status-internals",
+            "Reference: https://docs.nautobot.com/projects/core/en/next/user-guide/platform-functionality/status/#status-internals",
         ),
     }
 

--- a/pylint_nautobot/incorrect_base_class.py
+++ b/pylint_nautobot/incorrect_base_class.py
@@ -68,5 +68,4 @@ class NautobotIncorrectBaseClassChecker(BaseChecker):
         ancestor_class_types = [ancestor.qname() for ancestor in node.ancestors()]
         for base_class, nautobot_base_class in self.external_to_nautobot_class_mapping:
             if base_class in ancestor_class_types and nautobot_base_class not in ancestor_class_types:
-                self.add_message(msgid="nb-incorrect-base-class", node=node,
-                                 args=(base_class, nautobot_base_class))
+                self.add_message(msgid="nb-incorrect-base-class", node=node, args=(base_class, nautobot_base_class))

--- a/pylint_nautobot/incorrect_base_class.py
+++ b/pylint_nautobot/incorrect_base_class.py
@@ -51,7 +51,7 @@ class NautobotIncorrectBaseClassChecker(BaseChecker):
     name = "nautobot-incorrect-base-class"
     msgs = {
         "E4242": (
-            "Uses incorrect base classes.",
+            "Uses incorrect base classes (%s -> %s).",
             "nb-incorrect-base-class",
             "All classes should inherit from the correct base classes.",
         )
@@ -68,4 +68,5 @@ class NautobotIncorrectBaseClassChecker(BaseChecker):
         ancestor_class_types = [ancestor.qname() for ancestor in node.ancestors()]
         for base_class, nautobot_base_class in self.external_to_nautobot_class_mapping:
             if base_class in ancestor_class_types and nautobot_base_class not in ancestor_class_types:
-                self.add_message(msgid="nb-incorrect-base-class", node=node)
+                self.add_message(msgid="nb-incorrect-base-class", node=node,
+                                 args=(base_class, nautobot_base_class))

--- a/pylint_nautobot/model_label.py
+++ b/pylint_nautobot/model_label.py
@@ -58,9 +58,9 @@ class NautobotModelLabelChecker(BaseChecker):
     name = "nautobot-model-label"
     msgs = {
         "C4701": (
-            "Model's app_label.model_name should be retrieved with `model._meta.label_lower`",
+            "Model's 'app_label.model_name' should be retrieved with 'model._meta.label_lower'",
             "nb-used-model-label-construction",
-            "Replace f-string `{model._meta.app_label}.{model._meta.model}` with `{model._meta.label_lower}`",
+            "Replace f-string '{model._meta.app_label}.{model._meta.model}' with '{model._meta.label_lower}'.",
         ),
     }
 
@@ -70,7 +70,7 @@ class NautobotModelLabelChecker(BaseChecker):
         Matches the following pattern inside the f-string:
             {model._meta.app_label}.{model._meta.model}
 
-        `model` can be any variable name, its value is cached inside `state["model_name"]` and used to check the next
+        'model' can be any variable name, its value is cached inside 'state["model_name"]' and used to check the next
         node.
 
         Function iterates node.values (list of AST nodes the f-string is composed of) and checks if the nodes match

--- a/pylint_nautobot/replaced_models.py
+++ b/pylint_nautobot/replaced_models.py
@@ -15,32 +15,32 @@ class NautobotReplacedModelsImportChecker(BaseChecker):
         "E4211": (
             "Imports a model that has been replaced (dcim.DeviceRole -> extras.Role).",
             "nb-replaced-device-role",
-            "https://docs.nautobot.com/projects/core/en/next/installation/upgrading-from-nautobot-v1/#generic-role-model",
+            "Reference: https://docs.nautobot.com/projects/core/en/next/development/apps/migration/model-updates/extras/#replace-role-related-models-with-generic-role-model",
         ),
         "E4212": (
             "Imports a model that has been replaced (dcim.RackRole -> extras.Role).",
             "nb-replaced-rack-role",
-            "https://docs.nautobot.com/projects/core/en/next/installation/upgrading-from-nautobot-v1/#generic-role-model",
+            "Reference: https://docs.nautobot.com/projects/core/en/next/development/apps/migration/model-updates/extras/#replace-role-related-models-with-generic-role-model",
         ),
         "E4213": (
             "Imports a model that has been replaced (ipam.Role -> extras.Role).",
             "nb-replaced-ipam-role",
-            "https://docs.nautobot.com/projects/core/en/next/installation/upgrading-from-nautobot-v1/#generic-role-model",
+            "Reference: https://docs.nautobot.com/projects/core/en/next/development/apps/migration/model-updates/extras/#replace-role-related-models-with-generic-role-model",
         ),
         "E4214": (
             "Imports a model that has been replaced (dcim.Region -> dcim.Location).",
             "nb-replaced-region",
-            "https://docs.nautobot.com/projects/core/en/next/installation/upgrading-from-nautobot-v1/#site-and-region-models",
+            "Reference: https://docs.nautobot.com/projects/core/en/next/development/apps/migration/model-updates/dcim/#replace-site-and-region-with-location-model",
         ),
         "E4215": (
             "Imports a model that has been replaced (dcim.Site -> dcim.Location).",
             "nb-replaced-site",
-            "https://docs.nautobot.com/projects/core/en/next/installation/upgrading-from-nautobot-v1/#site-and-region-models",
+            "Reference: https://docs.nautobot.com/projects/core/en/next/development/apps/migration/model-updates/dcim/#replace-site-and-region-with-location-model",
         ),
         "E4216": (
             "Imports a model that has been replaced (ipam.Aggregate -> ipam.Prefix).",
             "nb-replaced-aggregate",
-            "https://docs.nautobot.com/projects/core/en/next/installation/upgrading-from-nautobot-v1/#aggregate-migrated-to-prefix",
+            "Reference: https://docs.nautobot.com/projects/core/en/next/development/apps/migration/model-updates/ipam/#replace-aggregate-with-prefix",
         ),
     }
 

--- a/pylint_nautobot/string_field_blank_null.py
+++ b/pylint_nautobot/string_field_blank_null.py
@@ -16,7 +16,9 @@ class NautobotStringFieldBlankNull(BaseChecker):
         "E4261": (
             "Uses bad parameter combination for TextField/CharField.",
             "nb-string-field-blank-null",
-            "Don't use blank=true and null=true on TextField or CharField",
+            'Don\'t use blank=true and null=true on TextField or CharField. \
+             It avoids confusion between a value of None and a value of ""\
+             potentially having different meanings.',
         ),
     }
 
@@ -35,10 +37,13 @@ class NautobotStringFieldBlankNull(BaseChecker):
             # We are only interested in assignments to a call
             if not isinstance(child_node.value, Call):
                 continue
+            # We are only interested in calls to these two models
+            if child_node.value.func.attrname not in ("TextField", "CharField"):
+                continue
             for keyword in child_node.value.keywords:
                 if keyword.arg == "blank" and keyword.value.value is True:
                     blank = True
                 if keyword.arg == "null" and keyword.value.value is True:
                     null = True
             if null and blank:
-                self.add_message(msgid="nb-string-field-blank-null", node=node)
+                self.add_message(msgid="nb-string-field-blank-null", node=child_node)

--- a/pylint_nautobot/string_field_blank_null.py
+++ b/pylint_nautobot/string_field_blank_null.py
@@ -37,8 +37,11 @@ class NautobotStringFieldBlankNull(BaseChecker):
             # We are only interested in assignments to a call
             if not isinstance(child_node.value, Call):
                 continue
+            # Encountered values: "CharField" or "models.CharField"
+            # because they can be ast Name or Attribute nodes
+            child_node_name = child_node.value.func.as_string().split(".")[-1]
             # We are only interested in calls to these two models
-            if child_node.value.func.attrname not in ("TextField", "CharField"):
+            if child_node_name not in ("TextField", "CharField"):
                 continue
             for keyword in child_node.value.keywords:
                 if keyword.arg == "blank" and keyword.value.value is True:

--- a/tests/inputs/string-field-blank-null/good_field.py
+++ b/tests/inputs/string-field-blank-null/good_field.py
@@ -2,12 +2,14 @@ from django.db import models
 from django.db.models import CharField
 from nautobot.core.models import BaseModel
 
+
 class MyModelOne(BaseModel):
     name = CharField(blank=True)
 
 
 class MyModelTwo(BaseModel):
     name = CharField(null=True)
+
 
 class MyModelThree(BaseModel):
     name = models.TextField(null=True)

--- a/tests/inputs/string-field-blank-null/good_field.py
+++ b/tests/inputs/string-field-blank-null/good_field.py
@@ -1,6 +1,6 @@
+from django.db import models
 from django.db.models import CharField
 from nautobot.core.models import BaseModel
-
 
 class MyModelOne(BaseModel):
     name = CharField(blank=True)
@@ -8,3 +8,6 @@ class MyModelOne(BaseModel):
 
 class MyModelTwo(BaseModel):
     name = CharField(null=True)
+
+class MyModelThree(BaseModel):
+    name = models.TextField(null=True)

--- a/tests/test_incorrect_base_class.py
+++ b/tests/test_incorrect_base_class.py
@@ -16,6 +16,7 @@ _EXPECTED_ERROR_ARGS = {
         "line": 4,
         "col_offset": 0,
         "node": lambda module_node: module_node.body[1],
+        "args": ('django.db.models.base.Model', 'nautobot.core.models.BaseModel')
     },
 }
 

--- a/tests/test_incorrect_base_class.py
+++ b/tests/test_incorrect_base_class.py
@@ -16,7 +16,7 @@ _EXPECTED_ERROR_ARGS = {
         "line": 4,
         "col_offset": 0,
         "node": lambda module_node: module_node.body[1],
-        "args": ('django.db.models.base.Model', 'nautobot.core.models.BaseModel')
+        "args": ("django.db.models.base.Model", "nautobot.core.models.BaseModel"),
     },
 }
 

--- a/tests/test_string_field_blank_null.py
+++ b/tests/test_string_field_blank_null.py
@@ -13,8 +13,8 @@ _INPUTS_PATH = Path(__file__).parent / "inputs/string-field-blank-null/"
 _EXPECTED_ERRORS = {
     "field": {
         "msg_id": "nb-string-field-blank-null",
-        "line": 5,
-        "col_offset": 0,
+        "line": 6,
+        "col_offset": 4,
         "node": lambda module_node: module_node.body[2],
     },
 }

--- a/tests/test_string_field_blank_null.py
+++ b/tests/test_string_field_blank_null.py
@@ -15,7 +15,7 @@ _EXPECTED_ERRORS = {
         "msg_id": "nb-string-field-blank-null",
         "line": 6,
         "col_offset": 4,
-        "node": lambda module_node: module_node.body[2],
+        "node": lambda module_node: module_node.body[2].body[0],
     },
 }
 


### PR DESCRIPTION
- Adds documentation section about using `--help-msg` to view more details about a rule.
- Fixes scoping issues in `nautobot-string-field-blank-null` and improves rule help.
- `nautobot-string-field-blank-null` now points to the offending line instead of the class definition.
- Fixes broken links to docs.

Fixes #45 and #48