### PR TITLE
Allow Nautobot prerelease versions in is_version_compatible

### DIFF
--- a/pylint_nautobot/utils.py
+++ b/pylint_nautobot/utils.py
@@ -173,7 +173,7 @@ def is_version_compatible(specifier_set: Union[str, SpecifierSet]) -> bool:
     if not specifier_set:
         return True
     if isinstance(specifier_set, str):
-        specifier_set = SpecifierSet(specifier_set)
+        specifier_set = SpecifierSet(specifier_set, prereleases=True)
     return specifier_set.contains(MINIMUM_NAUTOBOT_VERSION)
 
 


### PR DESCRIPTION
Add `prereleases=True` to `SpecifierSet()` initialization so that Nautobot versions like `3.0.0a1` correctly satisfy constraints like `">=2,<4"`.