### PR TITLE
NAPPS-369: Ensure Filter field name does not have a double underscore

### DIFF
--- a/pylint_nautobot/__init__.py
+++ b/pylint_nautobot/__init__.py
@@ -6,6 +6,7 @@ from pylint.lint import PyLinter
 
 from .code_location_changes import NautobotCodeLocationChangesChecker
 from .deprecated_status_model import NautobotDeprecatedStatusModelChecker
+from .dunder_filter_fields import NautobotDunderFilterFieldChecker
 from .incorrect_base_class import NautobotIncorrectBaseClassChecker
 from .model_label import NautobotModelLabelChecker
 from .q_search_filter import NautobotUseSearchFilterChecker
@@ -20,6 +21,7 @@ __version__ = metadata.version(__name__)
 CHECKERS = [
     NautobotCodeLocationChangesChecker,
     NautobotDeprecatedStatusModelChecker,
+    NautobotDunderFilterFieldChecker,
     NautobotIncorrectBaseClassChecker,
     NautobotModelLabelChecker,
     NautobotReplacedModelsImportChecker,

--- a/pylint_nautobot/deprecated_status_model.py
+++ b/pylint_nautobot/deprecated_status_model.py
@@ -21,5 +21,5 @@ class NautobotDeprecatedStatusModelChecker(BaseChecker):
 
     def visit_classdef(self, node):
         """Visit class definitions."""
-        if find_ancestor(node, ["nautobot.extras.models.statuses.StatusModel"], lambda item: item):
+        if find_ancestor(node, ["nautobot.extras.models.statuses.StatusModel"]):
             self.add_message("nb-status-field-instead-of-status-model", node=node)

--- a/pylint_nautobot/deprecated_status_model.py
+++ b/pylint_nautobot/deprecated_status_model.py
@@ -2,6 +2,8 @@
 
 from pylint.checkers import BaseChecker
 
+from .utils import find_ancestor
+
 
 class NautobotDeprecatedStatusModelChecker(BaseChecker):
     """Discourage the usage of deprecated StatusModel and encourage the usage of StatusField."""
@@ -19,6 +21,5 @@ class NautobotDeprecatedStatusModelChecker(BaseChecker):
 
     def visit_classdef(self, node):
         """Visit class definitions."""
-        ancestor_class_types = [ancestor.qname() for ancestor in node.ancestors()]
-        if "nautobot.extras.models.statuses.StatusModel" in ancestor_class_types:
+        if find_ancestor(node, ["nautobot.extras.models.statuses.StatusModel"], lambda item: item):
             self.add_message("nb-status-field-instead-of-status-model", node=node)

--- a/pylint_nautobot/dunder_filter_fields.py
+++ b/pylint_nautobot/dunder_filter_fields.py
@@ -32,7 +32,7 @@ class NautobotDunderFilterFieldChecker(BaseChecker):
 
     def visit_classdef(self, node: ClassDef):
         """Visit class definitions."""
-        if not find_ancestor(node, ["nautobot.extras.filters.NautobotFilterSet"], lambda item: item):
+        if not find_ancestor(node, ["nautobot.extras.filters.NautobotFilterSet"]):
             return
 
         for child_node in node.get_children():

--- a/pylint_nautobot/dunder_filter_fields.py
+++ b/pylint_nautobot/dunder_filter_fields.py
@@ -7,7 +7,16 @@ from .utils import find_ancestor
 
 
 class NautobotDunderFilterFieldChecker(BaseChecker):
-    """Visit NautobotFilterSet subclasses and check for use of __ in the field name."""
+    """Visit NautobotFilterSet subclasses and check for use of __ in the field name.
+
+    For example, `field__example` is reserved for nested lookups and should not be used as a filter field name.
+    Instead, use `field_example` or similar.
+
+    Example:
+        class MyFilterSet(NautobotFilterSet):
+            name__or = django_filters.CharFilter()
+            # This will raise a warning
+    """
 
     version_specifier = ">=2,<4"
 

--- a/pylint_nautobot/dunder_filter_fields.py
+++ b/pylint_nautobot/dunder_filter_fields.py
@@ -1,0 +1,32 @@
+"""Warn about double underscore filter fields in NautobotFilterSet subclasses."""
+
+from astroid import Assign, AssignName, ClassDef
+from pylint.checkers import BaseChecker
+
+
+class NautobotDunderFilterFieldChecker(BaseChecker):
+    """Visit NautobotFilterSet subclasses and check for use of __ in the field name."""
+
+    version_specifier = ">=2,<4"
+
+    name = "nautobot-warn-dunder-filter-field"
+    msgs = {
+        "W4275": (
+            "Avoid using double underscores in filter field names.",
+            "nb-warn-dunder-filter-field",
+            "Double underscores in filter field names are reserved for nested lookups and can cause unexpected behavior. "
+            "Use single underscores instead.",
+        ),
+    }
+
+    def visit_classdef(self, node: ClassDef):
+        """Visit class definitions."""
+        ancestors = [ancestor.qname() for ancestor in node.ancestors()]
+        if "nautobot.extras.filters.NautobotFilterSet" not in ancestors:
+            return
+
+        for child_node in node.get_children():
+            if isinstance(child_node, Assign) and any(
+                isinstance(target, AssignName) and "__" in target.name for target in child_node.targets
+            ):
+                self.add_message("nb-warn-dunder-filter-field", node=child_node)

--- a/pylint_nautobot/dunder_filter_fields.py
+++ b/pylint_nautobot/dunder_filter_fields.py
@@ -3,6 +3,8 @@
 from astroid import Assign, AssignName, ClassDef
 from pylint.checkers import BaseChecker
 
+from .utils import find_ancestor
+
 
 class NautobotDunderFilterFieldChecker(BaseChecker):
     """Visit NautobotFilterSet subclasses and check for use of __ in the field name."""
@@ -21,8 +23,7 @@ class NautobotDunderFilterFieldChecker(BaseChecker):
 
     def visit_classdef(self, node: ClassDef):
         """Visit class definitions."""
-        ancestors = [ancestor.qname() for ancestor in node.ancestors()]
-        if "nautobot.extras.filters.NautobotFilterSet" not in ancestors:
+        if not find_ancestor(node, ["nautobot.extras.filters.NautobotFilterSet"], lambda item: item):
             return
 
         for child_node in node.get_children():

--- a/pylint_nautobot/q_search_filter.py
+++ b/pylint_nautobot/q_search_filter.py
@@ -3,6 +3,8 @@
 from astroid import Assign, AssignName, ClassDef, FunctionDef
 from pylint.checkers import BaseChecker
 
+from .utils import find_ancestor
+
 
 class NautobotUseSearchFilterChecker(BaseChecker):
     """Visit NautobotFilterSet subclasses and check for use of `q = SearchFilter`, instead of `q = django_filters.CharField`."""
@@ -33,8 +35,7 @@ class NautobotUseSearchFilterChecker(BaseChecker):
 
     def visit_classdef(self, node: ClassDef):
         """Visit class definitions."""
-        ancestors = [ancestor.qname() for ancestor in node.ancestors()]
-        if "nautobot.extras.filters.NautobotFilterSet" not in ancestors:
+        if not find_ancestor(node, ["nautobot.extras.filters.NautobotFilterSet"], lambda item: item):
             return
 
         for child_node in node.get_children():

--- a/pylint_nautobot/q_search_filter.py
+++ b/pylint_nautobot/q_search_filter.py
@@ -33,20 +33,20 @@ class NautobotUseSearchFilterChecker(BaseChecker):
 
     def visit_classdef(self, node: ClassDef):
         """Visit class definitions."""
-        for ancestor in node.ancestors():
-            if ancestor.qname() != "nautobot.extras.filters.NautobotFilterSet":
-                return
+        ancestors = [ancestor.qname() for ancestor in node.ancestors()]
+        if "nautobot.extras.filters.NautobotFilterSet" not in ancestors:
+            return
 
-            for child_node in node.get_children():
-                if isinstance(child_node, Assign) and any(
-                    isinstance(target, AssignName) and target.name == "q" for target in child_node.targets
-                ):
-                    child_node_name = child_node.value.func.as_string().split(".")[-1]
-                    # The `q` attribute should not be a CharFilter, instead it should be a SearchFilter
-                    if child_node_name == "CharFilter":
-                        self.add_message("nb-no-char-filter-q", node=child_node)
-                    # Warn but allow override if the `q` attribute is not a SearchFilter as this could be inherited from the SearchFilter
-                    elif child_node_name != "SearchFilter":
-                        self.add_message("nb-use-search-filter", node=child_node)
-                if isinstance(child_node, FunctionDef) and child_node.name == "search":
-                    self.add_message("nb-no-search-function", node=child_node)
+        for child_node in node.get_children():
+            if isinstance(child_node, Assign) and any(
+                isinstance(target, AssignName) and target.name == "q" for target in child_node.targets
+            ):
+                child_node_name = child_node.value.func.as_string().split(".")[-1]
+                # The `q` attribute should not be a CharFilter, instead it should be a SearchFilter
+                if child_node_name == "CharFilter":
+                    self.add_message("nb-no-char-filter-q", node=child_node)
+                # Warn but allow override if the `q` attribute is not a SearchFilter as this could be inherited from the SearchFilter
+                elif child_node_name != "SearchFilter":
+                    self.add_message("nb-use-search-filter", node=child_node)
+            if isinstance(child_node, FunctionDef) and child_node.name == "search":
+                self.add_message("nb-no-search-function", node=child_node)

--- a/pylint_nautobot/q_search_filter.py
+++ b/pylint_nautobot/q_search_filter.py
@@ -35,7 +35,7 @@ class NautobotUseSearchFilterChecker(BaseChecker):
 
     def visit_classdef(self, node: ClassDef):
         """Visit class definitions."""
-        if not find_ancestor(node, ["nautobot.extras.filters.NautobotFilterSet"], lambda item: item):
+        if not find_ancestor(node, ["nautobot.extras.filters.NautobotFilterSet"]):
             return
 
         for child_node in node.get_children():

--- a/pylint_nautobot/string_field_blank_null.py
+++ b/pylint_nautobot/string_field_blank_null.py
@@ -3,6 +3,8 @@
 from astroid import Assign, Call, ClassDef
 from pylint.checkers import BaseChecker
 
+from .utils import find_ancestor
+
 
 class NautobotStringFieldBlankNull(BaseChecker):
     """Visit classes to find class children on models who are CharField's or TextField's and check whether they are configured well."""
@@ -23,8 +25,7 @@ class NautobotStringFieldBlankNull(BaseChecker):
     def visit_classdef(self, node: ClassDef):
         """Visit class definitions."""
         # We only care about models
-        ancestors = [ancestor.qname() for ancestor in node.ancestors()]
-        if "django.db.models.base.Model" not in ancestors:
+        if not find_ancestor(node, ["django.db.models.base.Model"], lambda item: item):
             return
 
         for child_node in node.get_children():

--- a/pylint_nautobot/string_field_blank_null.py
+++ b/pylint_nautobot/string_field_blank_null.py
@@ -25,7 +25,7 @@ class NautobotStringFieldBlankNull(BaseChecker):
     def visit_classdef(self, node: ClassDef):
         """Visit class definitions."""
         # We only care about models
-        if not find_ancestor(node, ["django.db.models.base.Model"], lambda item: item):
+        if not find_ancestor(node, ["django.db.models.base.Model"]):
             return
 
         for child_node in node.get_children():

--- a/pylint_nautobot/utils.py
+++ b/pylint_nautobot/utils.py
@@ -159,9 +159,7 @@ def get_model_name_from_attr(model_attr: Assign) -> str:
 
 
 def find_ancestor(
-    node: ClassDef,
-    ancestors: Iterable[T],
-    get_value: Optional[Callable[[T], str]] = None
+    node: ClassDef, ancestors: Iterable[T], get_value: Optional[Callable[[T], str]] = None
 ) -> Optional[T]:
     """Find the class ancestor from the list of ancestors."""
     ancestor_class_types = [ancestor.qname() for ancestor in node.ancestors()]

--- a/pylint_nautobot/utils.py
+++ b/pylint_nautobot/utils.py
@@ -158,6 +158,7 @@ def get_model_name_from_attr(model_attr: Assign) -> str:
     return model_attr_chain[-1]
 
 
+# TODO: Remove the get_value callable and just accept a list directly.
 def find_ancestor(node: ClassDef, ancestors: Iterable[T], get_value: Callable[[T], str]) -> Optional[T]:
     """Find the class ancestor from the list of ancestors."""
     ancestor_class_types = [ancestor.qname() for ancestor in node.ancestors()]

--- a/pylint_nautobot/utils.py
+++ b/pylint_nautobot/utils.py
@@ -158,12 +158,17 @@ def get_model_name_from_attr(model_attr: Assign) -> str:
     return model_attr_chain[-1]
 
 
-# TODO: Remove the get_value callable and just accept a list directly.
-def find_ancestor(node: ClassDef, ancestors: Iterable[T], get_value: Callable[[T], str]) -> Optional[T]:
+def find_ancestor(
+    node: ClassDef,
+    ancestors: Iterable[T],
+    get_value: Optional[Callable[[T], str]] = None
+) -> Optional[T]:
     """Find the class ancestor from the list of ancestors."""
     ancestor_class_types = [ancestor.qname() for ancestor in node.ancestors()]
     for checked_ancestor in ancestors:
-        if get_value(checked_ancestor) in ancestor_class_types:
+        if get_value and get_value(checked_ancestor) in ancestor_class_types:
+            return checked_ancestor
+        if not get_value and checked_ancestor in ancestor_class_types:
             return checked_ancestor
 
     return None

--- a/tests/inputs/dunder-filter-fields/error_filter_set.py
+++ b/tests/inputs/dunder-filter-fields/error_filter_set.py
@@ -8,4 +8,3 @@ class ValidNameFilterFilterSet(NautobotFilterSet):
         lookup_expr="icontains",
         label="Serial Number",
     )
-

--- a/tests/inputs/dunder-filter-fields/error_filter_set.py
+++ b/tests/inputs/dunder-filter-fields/error_filter_set.py
@@ -1,12 +1,11 @@
-from nautobot.apps.filters import NautobotFilterSet, SearchFilter
+from nautobot.apps.filters import MultiValueCharFilter, NautobotFilterSet
 
 
 class ValidNameFilterFilterSet(NautobotFilterSet):
     """Filter for AddressObject."""
 
-    q__name = SearchFilter(
-        filter_predicates={
-            "name": ["name__icontains"],
-            "description": ["description__icontains"],
-        }
+    serial__number = MultiValueCharFilter(
+        lookup_expr="icontains",
+        label="Serial Number",
     )
+

--- a/tests/inputs/dunder-filter-fields/error_filter_set.py
+++ b/tests/inputs/dunder-filter-fields/error_filter_set.py
@@ -1,0 +1,12 @@
+from nautobot.apps.filters import NautobotFilterSet, SearchFilter
+
+
+class ValidNameFilterFilterSet(NautobotFilterSet):
+    """Filter for AddressObject."""
+
+    q__name = SearchFilter(
+        filter_predicates={
+            "name": ["name__icontains"],
+            "description": ["description__icontains"],
+        }
+    )

--- a/tests/inputs/dunder-filter-fields/good_filter_set.py
+++ b/tests/inputs/dunder-filter-fields/good_filter_set.py
@@ -1,12 +1,10 @@
-from nautobot.apps.filters import NautobotFilterSet, SearchFilter
+from nautobot.apps.filters import MultiValueCharFilter, NautobotFilterSet
 
 
 class ValidNameFilterFilterSet(NautobotFilterSet):
     """Filter for AddressObject."""
 
-    q_name = SearchFilter(
-        filter_predicates={
-            "name": ["name__icontains"],
-            "description": ["description__icontains"],
-        }
+    serial_number = MultiValueCharFilter(
+        lookup_expr="icontains",
+        label="Serial Number",
     )

--- a/tests/inputs/dunder-filter-fields/good_filter_set.py
+++ b/tests/inputs/dunder-filter-fields/good_filter_set.py
@@ -1,0 +1,12 @@
+from nautobot.apps.filters import NautobotFilterSet, SearchFilter
+
+
+class ValidNameFilterFilterSet(NautobotFilterSet):
+    """Filter for AddressObject."""
+
+    q_name = SearchFilter(
+        filter_predicates={
+            "name": ["name__icontains"],
+            "description": ["description__icontains"],
+        }
+    )

--- a/tests/test_dunder_filter_fields.py
+++ b/tests/test_dunder_filter_fields.py
@@ -10,7 +10,7 @@ _EXPECTED_ERRORS = {
     "filter_set": {
         "msg_id": "nb-warn-dunder-filter-field",
         "line": 7,
-        "end_line": 12,
+        "end_line": 10,
         "col_offset": 4,
         "end_col_offset": 5,
         "node": lambda module_node: module_node.body[1].body[0],

--- a/tests/test_dunder_filter_fields.py
+++ b/tests/test_dunder_filter_fields.py
@@ -1,0 +1,32 @@
+"""Tests for use of SearchFilter on NautobotFilterSets instead of custom `q` search functions.."""
+
+from pylint.testutils import CheckerTestCase
+
+from pylint_nautobot.dunder_filter_fields import NautobotDunderFilterFieldChecker
+
+from .utils import assert_error_file, assert_good_file, parametrize_error_files, parametrize_good_files
+
+_EXPECTED_ERRORS = {
+    "filter_set": {
+        "msg_id": "nb-warn-dunder-filter-field",
+        "line": 7,
+        "end_line": 12,
+        "col_offset": 4,
+        "end_col_offset": 5,
+        "node": lambda module_node: module_node.body[1].body[0],
+    },
+}
+
+
+class TestNautobotDunderFilterFieldChecker(CheckerTestCase):
+    """Test dunder in FilterSet fields."""
+
+    CHECKER_CLASS = NautobotDunderFilterFieldChecker
+
+    @parametrize_error_files(__file__, _EXPECTED_ERRORS)
+    def test_error(self, filename, expected_error):
+        assert_error_file(self, filename, expected_error)
+
+    @parametrize_good_files(__file__)
+    def test_good(self, filename):
+        assert_good_file(self, filename)


### PR DESCRIPTION
This PR introduces a new rule to warn if any filter field name contains a double underscore. This is a warning as using double underscores is permitted, but is used for nested filters. If you are not doing nested filters, you should instead use a single underscore.