### PR TITLE
Adds TransactionTestCase to nautobot-incorrect-base-class

### DIFF
--- a/changes/136.added
+++ b/changes/136.added
@@ -1,0 +1,1 @@
+Added `django.test.TransactionTestCase` to the incorrect base class checker.

--- a/pylint_nautobot/incorrect_base_class.py
+++ b/pylint_nautobot/incorrect_base_class.py
@@ -37,6 +37,12 @@ _CLASS_MAPPING = (
         "correct": "nautobot.core.forms.forms.BootstrapMixin",
         "display": "nautobot.apps.forms.BootstrapMixin",
     },
+    {
+        "versions": ">=2.0",
+        "incorrect": "django.test.testcases.TransactionTestCase",
+        "correct": "nautobot.core.testing.TransactionTestCase",
+        "display": "nautobot.apps.testing.TransactionTestCase",
+    },
 )
 
 

--- a/tests/inputs/incorrect-base-class/error_transaction_test_case.py
+++ b/tests/inputs/incorrect-base-class/error_transaction_test_case.py
@@ -1,0 +1,5 @@
+from django.test import TransactionTestCase
+
+
+class MyTestCase(TransactionTestCase):
+    pass

--- a/tests/inputs/incorrect-base-class/good_transaction_test_case.py
+++ b/tests/inputs/incorrect-base-class/good_transaction_test_case.py
@@ -1,0 +1,5 @@
+from nautobot.apps.testing import TransactionTestCase
+
+
+class MyTestCase(TransactionTestCase):
+    pass

--- a/tests/test_incorrect_base_class.py
+++ b/tests/test_incorrect_base_class.py
@@ -52,6 +52,16 @@ _EXPECTED_ERRORS = {
         "node": _find_error_node,
         "args": ("django.forms.models.BaseModelForm", "nautobot.apps.forms.NautobotModelForm"),
     },
+    "transaction_test_case": {
+        "versions": ">=2",
+        "msg_id": "nb-incorrect-base-class",
+        "line": 4,
+        "end_line": 4,
+        "col_offset": 0,
+        "end_col_offset": 16,
+        "node": _find_error_node,
+        "args": ("django.test.testcases.TransactionTestCase", "nautobot.apps.testing.TransactionTestCase"),
+    },
 }
 
 


### PR DESCRIPTION
This PR just adds the `nautobot.apps.testing.TransactionTestCase` to the existing `nautobot-incorrect-base-class` rule.