### PR TITLE
Added nautobot-teardown-super rule

### DIFF
--- a/changes/137.added
+++ b/changes/137.added
@@ -1,0 +1,1 @@
+Added a new checker to ensure test class `tearDown` methods call `super().tearDown()`.

--- a/pylint_nautobot/__init__.py
+++ b/pylint_nautobot/__init__.py
@@ -14,6 +14,7 @@ from .q_search_filter import NautobotUseSearchFilterChecker
 from .replaced_models import NautobotReplacedModelsImportChecker
 from .string_field_blank_null import NautobotStringFieldBlankNull
 from .sub_class_name import NautobotSubClassNameChecker
+from .teardown_super import NautobotTearDownSuperChecker
 from .use_fields_all import NautobotUseFieldsAllChecker
 from .utils import is_version_compatible
 
@@ -29,6 +30,7 @@ CHECKERS = [
     NautobotReplacedModelsImportChecker,
     NautobotStringFieldBlankNull,
     NautobotSubClassNameChecker,
+    NautobotTearDownSuperChecker,
     NautobotUseFieldsAllChecker,
     NautobotUseSearchFilterChecker,
 ]

--- a/pylint_nautobot/teardown_super.py
+++ b/pylint_nautobot/teardown_super.py
@@ -1,0 +1,45 @@
+"""Check for tearDown methods that don't call super().tearDown()."""
+
+from astroid.nodes import Attribute, Call, ClassDef, FunctionDef, Name
+from pylint.checkers import BaseChecker
+
+
+def _has_super_teardown_call(node: FunctionDef) -> bool:
+    """Check if a function body contains a call to super().tearDown()."""
+    for child in node.nodes_of_class(Call):
+        func = child.func
+        if (
+            isinstance(func, Attribute)
+            and func.attrname == "tearDown"
+            and isinstance(func.expr, Call)
+            and isinstance(func.expr.func, Name)
+            and func.expr.func.name == "super"
+        ):
+            return True
+    return False
+
+
+class NautobotTearDownSuperChecker(BaseChecker):
+    """Ensure tearDown methods call super().tearDown()."""
+
+    version_specifier = ">=2,<4"
+
+    name = "nautobot-teardown-super"
+    msgs = {
+        "E4231": (
+            "tearDown method should call super().tearDown().",
+            "nb-teardown-super",
+            "All tearDown methods should call super().tearDown() to ensure proper test cleanup.",
+        ),
+    }
+
+    def visit_functiondef(self, node: FunctionDef):
+        """Visit function definitions looking for tearDown methods."""
+        if node.name != "tearDown":
+            return
+
+        if not isinstance(node.parent, ClassDef):
+            return
+
+        if not _has_super_teardown_call(node):
+            self.add_message("nb-teardown-super", node=node)

--- a/tests/inputs/teardown-super/error_teardown.py
+++ b/tests/inputs/teardown-super/error_teardown.py
@@ -1,0 +1,11 @@
+"""Test class with tearDown that does not call super().tearDown()."""
+
+from unittest import TestCase
+
+
+class MyTestCase(TestCase):
+    """Test case with missing super().tearDown()."""
+
+    def tearDown(self):
+        """Tear down test fixtures."""
+        pass

--- a/tests/inputs/teardown-super/good_teardown.py
+++ b/tests/inputs/teardown-super/good_teardown.py
@@ -1,0 +1,11 @@
+"""Test class with proper tearDown calling super().tearDown()."""
+
+from unittest import TestCase
+
+
+class MyTestCase(TestCase):
+    """Test case with proper tearDown."""
+
+    def tearDown(self):
+        """Tear down test fixtures."""
+        super().tearDown()

--- a/tests/test_teardown_super.py
+++ b/tests/test_teardown_super.py
@@ -1,0 +1,40 @@
+"""Tests for tear down super checker."""
+
+from pylint.testutils import CheckerTestCase
+
+from pylint_nautobot.teardown_super import NautobotTearDownSuperChecker
+
+from .utils import assert_error_file, assert_good_file, parametrize_error_files, parametrize_good_files
+
+
+def _find_teardown_node(module_node):
+    """Find the tearDown FunctionDef node."""
+    class_node = module_node.body[1]
+    return class_node.body[0]
+
+
+_EXPECTED_ERRORS = {
+    "teardown": {
+        "versions": ">=2",
+        "msg_id": "nb-teardown-super",
+        "line": 9,
+        "end_line": 9,
+        "col_offset": 4,
+        "end_col_offset": 16,
+        "node": _find_teardown_node,
+    },
+}
+
+
+class TestTearDownSuperChecker(CheckerTestCase):
+    """Test tear down super checker."""
+
+    CHECKER_CLASS = NautobotTearDownSuperChecker
+
+    @parametrize_error_files(__file__, _EXPECTED_ERRORS)
+    def test_error(self, filename, expected_error):
+        assert_error_file(self, filename, expected_error)
+
+    @parametrize_good_files(__file__)
+    def test_good(self, filename):
+        assert_good_file(self, filename)


### PR DESCRIPTION
This PR adds a pylint rule to check when a test class defines a `tearDown` method but fails to call `super().tearDown()`.