### PR TITLE
Added Job run argument unpacking checker

### DIFF
--- a/changes/125.added
+++ b/changes/125.added
@@ -1,0 +1,1 @@
+Added a checker to discourage `*args`/`**kwargs` unpacking operators in a Job's `run` method.

--- a/pylint_nautobot/__init__.py
+++ b/pylint_nautobot/__init__.py
@@ -9,6 +9,7 @@ from .deprecated_classes import NautobotDeprecatedClassChecker
 from .deprecated_status_model import NautobotDeprecatedStatusModelChecker
 from .dunder_filter_fields import NautobotDunderFilterFieldChecker
 from .incorrect_base_class import NautobotIncorrectBaseClassChecker
+from .job_run_unpacking import NautobotJobRunUnpackingChecker
 from .model_label import NautobotModelLabelChecker
 from .q_search_filter import NautobotUseSearchFilterChecker
 from .replaced_models import NautobotReplacedModelsImportChecker
@@ -25,6 +26,7 @@ CHECKERS = [
     NautobotDeprecatedStatusModelChecker,
     NautobotDunderFilterFieldChecker,
     NautobotIncorrectBaseClassChecker,
+    NautobotJobRunUnpackingChecker,
     NautobotModelLabelChecker,
     NautobotReplacedModelsImportChecker,
     NautobotStringFieldBlankNull,

--- a/pylint_nautobot/job_run_unpacking.py
+++ b/pylint_nautobot/job_run_unpacking.py
@@ -1,0 +1,44 @@
+"""Check for unpacking operators in Job run methods."""
+
+from astroid.nodes import ClassDef, FunctionDef
+from pylint.checkers import BaseChecker
+
+from .utils import find_ancestor
+
+# Job base class. Astroid resolves the public `nautobot.apps.jobs.Job` re-export to its
+# definition module, `nautobot.extras.jobs.Job`.
+_JOB_BASE_CLASSES = ("nautobot.extras.jobs.Job",)
+
+
+class NautobotJobRunUnpackingChecker(BaseChecker):
+    """Discourage `*args`/`**kwargs` in a Job's `run` method."""
+
+    version_specifier = ">=2,<4"
+
+    name = "nautobot-job-run-unpacking"
+    msgs = {
+        "E4294": (
+            "Job `run` method uses an unpacking operator (`%s`). Declare all job options as explicit keyword arguments.",
+            "nb-job-run-unpacking",
+            "In Nautobot v2+, all job options are explicit keyword arguments on `run`. "
+            "Using `*args`/`**kwargs` causes inconsistencies because the UI sends all form "
+            "fields while API/ORM calls only send provided fields.",
+        )
+    }
+
+    def visit_functiondef(self, node: FunctionDef):
+        """Visit function/method definitions, looking for a Job's `run` method."""
+        if node.name != "run":
+            return
+
+        parent = node.parent
+        if not isinstance(parent, ClassDef):
+            return
+        if not find_ancestor(parent, _JOB_BASE_CLASSES):
+            return
+
+        # `*args` and `**kwargs` are reported separately so the message names the operator.
+        if node.args.vararg:
+            self.add_message("nb-job-run-unpacking", node=node, args=(f"*{node.args.vararg}",))
+        if node.args.kwarg:
+            self.add_message("nb-job-run-unpacking", node=node, args=(f"**{node.args.kwarg}",))

--- a/tests/inputs/job-run-unpacking/both_args_and_kwargs.py
+++ b/tests/inputs/job-run-unpacking/both_args_and_kwargs.py
@@ -1,0 +1,6 @@
+from nautobot.apps.jobs import Job
+
+
+class MyJob(Job):
+    def run(self, *args, **kwargs):
+        pass

--- a/tests/inputs/job-run-unpacking/error_args.py
+++ b/tests/inputs/job-run-unpacking/error_args.py
@@ -1,0 +1,6 @@
+from nautobot.apps.jobs import Job
+
+
+class MyJob(Job):
+    def run(self, *args):
+        pass

--- a/tests/inputs/job-run-unpacking/error_data.py
+++ b/tests/inputs/job-run-unpacking/error_data.py
@@ -1,0 +1,6 @@
+from nautobot.apps.jobs import Job
+
+
+class MyJob(Job):
+    def run(self, **data):
+        pass

--- a/tests/inputs/job-run-unpacking/error_data.py
+++ b/tests/inputs/job-run-unpacking/error_data.py
@@ -1,4 +1,4 @@
-from nautobot.apps.jobs import Job
+from nautobot.extras.jobs import Job
 
 
 class MyJob(Job):

--- a/tests/inputs/job-run-unpacking/error_kwargs.py
+++ b/tests/inputs/job-run-unpacking/error_kwargs.py
@@ -1,0 +1,6 @@
+from nautobot.apps.jobs import Job
+
+
+class MyJob(Job):
+    def run(self, **kwargs):
+        pass

--- a/tests/inputs/job-run-unpacking/good_keyword_args.py
+++ b/tests/inputs/job-run-unpacking/good_keyword_args.py
@@ -1,0 +1,7 @@
+from nautobot.apps.jobs import Job
+
+
+class MyJob(Job):
+    # This test also verifies we don't get a false negative when using `*` to enforce arguments are passed as keyword-only.
+    def run(self, *, device, location=None):
+        pass

--- a/tests/inputs/job-run-unpacking/good_no_args.py
+++ b/tests/inputs/job-run-unpacking/good_no_args.py
@@ -1,0 +1,6 @@
+from nautobot.apps.jobs import Job
+
+
+class MyJob(Job):
+    def run(self):
+        pass

--- a/tests/inputs/job-run-unpacking/good_non_job_class.py
+++ b/tests/inputs/job-run-unpacking/good_non_job_class.py
@@ -1,0 +1,3 @@
+class NotAJob:
+    def run(self, **kwargs):
+        pass

--- a/tests/test_job_run_unpacking.py
+++ b/tests/test_job_run_unpacking.py
@@ -1,9 +1,11 @@
 """Tests for job run unpacking checker."""
 
 import astroid
+import pytest
 from pylint.testutils import CheckerTestCase, MessageTest
 
 from pylint_nautobot.job_run_unpacking import NautobotJobRunUnpackingChecker
+from pylint_nautobot.utils import is_version_compatible
 
 from .utils import (
     _INPUTS_PATH as INPUTS_PATH,
@@ -69,6 +71,7 @@ class TestJobRunUnpackingChecker(CheckerTestCase):
     def test_good(self, filename):
         assert_good_file(self, filename)
 
+    @pytest.mark.skipif(is_version_compatible("<2"), reason="Only applicable to Nautobot v2+")
     def test_args_and_kwargs(self):
         """A `run` method with both `*args` and `**kwargs` emits a message for each operator."""
         test_code = (INPUTS_PATH / _CHECKER_DIR / "both_args_and_kwargs.py").read_text(encoding="utf-8")

--- a/tests/test_job_run_unpacking.py
+++ b/tests/test_job_run_unpacking.py
@@ -1,0 +1,97 @@
+"""Tests for job run unpacking checker."""
+
+import astroid
+from pylint.testutils import CheckerTestCase, MessageTest
+
+from pylint_nautobot.job_run_unpacking import NautobotJobRunUnpackingChecker
+
+from .utils import (
+    _INPUTS_PATH as INPUTS_PATH,
+)
+from .utils import (
+    assert_error_file,
+    assert_good_file,
+    parametrize_error_files,
+    parametrize_good_files,
+)
+
+_CHECKER_DIR = "job-run-unpacking"
+
+
+def _find_error_node(module_node):
+    return module_node.body[1].body[0]  # ClassDef -> `run` FunctionDef
+
+
+_EXPECTED_ERRORS = {
+    "kwargs": {
+        "versions": ">=2",
+        "msg_id": "nb-job-run-unpacking",
+        "line": 5,
+        "end_line": 5,
+        "col_offset": 4,
+        "end_col_offset": 11,
+        "node": _find_error_node,
+        "args": ("**kwargs",),
+    },
+    "data": {
+        "versions": ">=2",
+        "msg_id": "nb-job-run-unpacking",
+        "line": 5,
+        "end_line": 5,
+        "col_offset": 4,
+        "end_col_offset": 11,
+        "node": _find_error_node,
+        "args": ("**data",),
+    },
+    "args": {
+        "versions": ">=2",
+        "msg_id": "nb-job-run-unpacking",
+        "line": 5,
+        "end_line": 5,
+        "col_offset": 4,
+        "end_col_offset": 11,
+        "node": _find_error_node,
+        "args": ("*args",),
+    },
+}
+
+
+class TestJobRunUnpackingChecker(CheckerTestCase):
+    """Test job run unpacking checker."""
+
+    CHECKER_CLASS = NautobotJobRunUnpackingChecker
+
+    @parametrize_error_files(__file__, _EXPECTED_ERRORS)
+    def test_error(self, filename, expected_error):
+        assert_error_file(self, filename, expected_error)
+
+    @parametrize_good_files(__file__)
+    def test_good(self, filename):
+        assert_good_file(self, filename)
+
+    def test_args_and_kwargs(self):
+        """A `run` method with both `*args` and `**kwargs` emits a message for each operator."""
+        test_code = (INPUTS_PATH / _CHECKER_DIR / "both_args_and_kwargs.py").read_text(encoding="utf-8")
+        module_node = astroid.parse(test_code)
+        run_node = _find_error_node(module_node)
+        with self.assertAddsMessages(
+            MessageTest(
+                msg_id="nb-job-run-unpacking",
+                node=run_node,
+                line=5,
+                end_line=5,
+                col_offset=4,
+                end_col_offset=11,
+                args=("*args",),
+            ),
+            MessageTest(
+                msg_id="nb-job-run-unpacking",
+                node=run_node,
+                line=5,
+                end_line=5,
+                col_offset=4,
+                end_col_offset=11,
+                args=("**kwargs",),
+            ),
+        ):
+            self.walk(module_node)


### PR DESCRIPTION
Closes: #125

This PR adds a new checker to raise an error when a Job's run method uses unpacking operators (e.g., `*args*`, `**kwargs`, `**data`)